### PR TITLE
Add SSL Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,26 @@ Customization
 
 Modules may override queue or exchange defaults built in a custom module by implementing
 `config/install//rabbitmq.config.yml`. See `src/Queue/QueueBase.php` for details.
+
+
+SSL
+-------
+it's similar to the normal one but you need to add 2 extra array
+This is an example of how should looks like the `settings.php`:
+```
+$settings['rabbitmq_credentials'] = [
+  'host' => 'host',
+'port' => 5672,
+'vhost' => '/',
+'username' => 'guest',
+'password' => 'guest',
+'ssl' => [
+  'verify_peer_name' => false,
+  'verify_peer' => false,
+  'local_pk' => '~/.ssh/id_rsa',
+],
+  'options' => [
+  'connection_timeout'    => 20,
+  'read_write_timeout'    => 20
+]];
+```

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains RabbitMQConnection.
- */
 namespace Drupal\rabbitmq;
 
 use Drupal\Core\Site\Settings;
@@ -49,6 +45,7 @@ class Connection {
    * @var \Drupal\Core\Site\Settings
    */
   protected $settings;
+
   /**
    * Constructor.
    *
@@ -62,44 +59,44 @@ class Connection {
     );
     $this->settings = $settings;
   }
+
   /**
    * Get a configured connection to RabbitMQ.
    */
-   public function getConnection() {
-     if (!self::$connection) {
-       $default_credentials = [
-         'host' => static::DEFAULT_SERVER_ALIAS,
-         'port' => static::DEFAULT_PORT,
-         'username' => static::DEFAULT_USER,
-         'password' => static::DEFAULT_PASS,
-         'vhost' => '/',
-       ];
-       $config_credentials = Settings::get('rabbitmq_credentials');
-       $credentials = !empty($config_credentials) ? $config_credentials : $default_credentials;
+  public function getConnection() {
+    if (!self::$connection) {
+      $default_credentials = [
+        'host' => static::DEFAULT_SERVER_ALIAS,
+        'port' => static::DEFAULT_PORT,
+        'username' => static::DEFAULT_USER,
+        'password' => static::DEFAULT_PASS,
+        'vhost' => '/',
+      ];
+      $config_credentials = Settings::get('rabbitmq_credentials');
+      $credentials = !empty($config_credentials) ? $config_credentials : $default_credentials;
 
-       if ($credentials['ssl'])
-       {
-         $connection = new AMQPSSLConnection(
-           $credentials['host'],
-           $credentials['port'],
-           $credentials['username'],
-           $credentials['password'],
-           $credentials['vhost'],
-           $credentials['ssl'],
-           $credentials['options']
-         );
-       }
-       else {
-         $connection = new AMQPStreamConnection(
-           $credentials['host'],
-           $credentials['port'],
-           $credentials['username'],
-           $credentials['password'],
-           $credentials['vhost']
-         );
-       }
-       self::$connection = $connection;
-     }
-     return self::$connection;
-   }
+      if ($credentials['ssl']) {
+        $connection = new AMQPSSLConnection(
+          $credentials['host'],
+          $credentials['port'],
+          $credentials['username'],
+          $credentials['password'],
+          $credentials['vhost'],
+          $credentials['ssl'],
+          $credentials['options']
+        );
+      }
+      else {
+        $connection = new AMQPStreamConnection(
+          $credentials['host'],
+          $credentials['port'],
+          $credentials['username'],
+          $credentials['password'],
+          $credentials['vhost']
+        );
+      }
+      self::$connection = $connection;
+    }
+    return self::$connection;
+  }
 }

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -1,8 +1,15 @@
 <?php
 
+/**
+ * @file
+ * Contains RabbitMQConnection.
+ */
 namespace Drupal\rabbitmq;
+
 use Drupal\Core\Site\Settings;
 use PhpAmqpLib\Connection\AMQPStreamConnection;
+use PhpAmqpLib\Connection\AMQPSSLConnection;
+
 /**
  * RabbitMQ connection class.
  *
@@ -70,11 +77,27 @@ class Connection {
        $config_credentials = Settings::get('rabbitmq_credentials');
        $credentials = !empty($config_credentials) ? $config_credentials : $default_credentials;
 
-       $connection = new AMQPStreamConnection(
-         $credentials['host'],
-         $credentials['port'], $credentials['username'],
-         $credentials['password'], $credentials['vhost']
-       );
+       if ($credentials['ssl'])
+       {
+         $connection = new AMQPSSLConnection(
+           $credentials['host'],
+           $credentials['port'],
+           $credentials['username'],
+           $credentials['password'],
+           $credentials['vhost'],
+           $credentials['ssl'],
+           $credentials['options']
+         );
+       }
+       else {
+         $connection = new AMQPStreamConnection(
+           $credentials['host'],
+           $credentials['port'],
+           $credentials['username'],
+           $credentials['password'],
+           $credentials['vhost']
+         );
+       }
        self::$connection = $connection;
      }
      return self::$connection;


### PR DESCRIPTION
Fixes #24 

In order to use the new SSL You need to put in your settings:
```
$settings['rabbitmq_credentials'] = [
  'host' => 'host',
'port' => 5672,
'vhost' => '/',
'username' => 'user',
'password' => 'pass',
'ssl' => [
  'verify_peer_name' => false,
  'verify_peer' => false,
  'local_pk' => '~/.ssh/id_rsa',
],
  'options' => [
  'connection_timeout'    => 20,
  'read_write_timeout'    => 20
]];
```